### PR TITLE
Add rate limiting to login endpoint

### DIFF
--- a/docs/login-system.md
+++ b/docs/login-system.md
@@ -18,6 +18,7 @@ O fluxo de autenticação do AmaDelivery combina um backend Express/Prisma com J
 ## Middleware e proteção de rotas
 - `authenticate` verifica o cabeçalho `Authorization`, valida o JWT com `JWT_SECRET` e anexa `req.authUser`. Falhas retornam erros estruturados (`MISSING_TOKEN`, `INVALID_AUTH_HEADER`, `INVALID_TOKEN`, `USER_NOT_FOUND`). 【F:server/src/middleware/authenticate.ts†L1-L45】
 - Todas as rotas sob `/api` (exceto `/auth`) passam pelo middleware, garantindo que operações com usuários, pedidos, entregadores etc. exijam token válido. 【F:server/src/routes/index.ts†L1-L33】
+- `loginRateLimiter` restringe o endpoint `POST /api/auth/login` a **5 tentativas por IP a cada 15 minutos**. Disparos excedidos retornam `429` com payload estruturado e cabeçalho `Retry-After`, além de gerar logs `console.warn` com o IP, caminho e janela aplicada para facilitar o monitoramento de ataques de força bruta. 【F:server/src/middleware/rate-limit.ts†L1-L33】【F:server/src/routes/auth.ts†L1-L76】
 
 ## Estado e armazenamento de sessão
 - `src/api/session.js` centraliza leitura/escrita de `{ token, user }`, incluindo *fallback* para ambientes não browser e limpeza automática de payloads corrompidos. 【F:src/api/session.js†L1-L36】

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,10 +10,11 @@
             "license": "ISC",
             "dependencies": {
                 "@prisma/client": "^6.16.2",
-                "bcryptjs": "^3.0.2",
+                "bcryptjs": "^2.4.3",
                 "cors": "^2.8.5",
                 "dotenv": "^17.2.2",
-                "express": "^5.1.0"
+                "express": "^5.1.0",
+                "express-rate-limit": "^8.1.0"
             },
             "devDependencies": {
                 "@types/cors": "^2.8.19",
@@ -689,13 +690,10 @@
             }
         },
         "node_modules/bcryptjs": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
-            "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
-            "license": "BSD-3-Clause",
-            "bin": {
-                "bcrypt": "bin/bcrypt"
-            }
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+            "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+            "license": "MIT"
         },
         "node_modules/body-parser": {
             "version": "2.2.0",
@@ -1133,6 +1131,24 @@
                 "url": "https://opencollective.com/express"
             }
         },
+        "node_modules/express-rate-limit": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.1.0.tgz",
+            "integrity": "sha512-4nLnATuKupnmwqiJc27b4dCFmB/T60ExgmtDD7waf4LdrbJ8CPZzZRHYErDYNhoz+ql8fUdYwM/opf90PoPAQA==",
+            "license": "MIT",
+            "dependencies": {
+                "ip-address": "10.0.1"
+            },
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/express-rate-limit"
+            },
+            "peerDependencies": {
+                "express": ">= 4.11"
+            }
+        },
         "node_modules/exsolve": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
@@ -1368,6 +1384,15 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "license": "ISC"
+        },
+        "node_modules/ip-address": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+            "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
+            }
         },
         "node_modules/ipaddr.js": {
             "version": "1.9.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,40 +1,39 @@
 {
-    "name":  "server",
-    "version":  "1.0.0",
-    "main":  "index.js",
-    "scripts":  {
-                    "dev":  "tsx watch src/server.ts",
-                    "build":  "tsc",
-                    "start":  "node dist/server.js",
-                    "lint":  "eslint .",
-                    "prisma:generate":  "prisma generate",
-                    "prisma:push":  "prisma db push",
-                    "prisma:migrate":  "prisma migrate dev",
-                    "test":  "echo \"No tests yet\"",
-                    "seed":  "prisma db seed"
-                },
-    "keywords":  [
-
-                 ],
-    "author":  "",
-    "license":  "ISC",
-    "description":  "AmaEats backend",
-    "dependencies":  {
-                         "@prisma/client":  "^6.16.2",
-                         "bcryptjs":  "^2.4.3",
-                         "cors":  "^2.8.5",
-                         "dotenv":  "^17.2.2",
-                         "express":  "^5.1.0"
-                     },
-    "devDependencies":  {
-                            "@types/cors":  "^2.8.19",
-                            "@types/express":  "^5.0.3",
-                            "@types/node":  "^24.5.2",
-                            "prisma":  "^6.16.2",
-                            "tsx":  "^4.20.5",
-                            "typescript":  "^5.9.2"
-                        },
-    "prisma":  {
-                   "seed":  "tsx prisma/seed.ts"
-               }
+    "name": "server",
+    "version": "1.0.0",
+    "main": "index.js",
+    "scripts": {
+        "dev": "tsx watch src/server.ts",
+        "build": "tsc",
+        "start": "node dist/server.js",
+        "lint": "eslint .",
+        "prisma:generate": "prisma generate",
+        "prisma:push": "prisma db push",
+        "prisma:migrate": "prisma migrate dev",
+        "test": "echo \"No tests yet\"",
+        "seed": "prisma db seed"
+    },
+    "keywords": [],
+    "author": "",
+    "license": "ISC",
+    "description": "AmaEats backend",
+    "dependencies": {
+        "@prisma/client": "^6.16.2",
+        "bcryptjs": "^2.4.3",
+        "cors": "^2.8.5",
+        "dotenv": "^17.2.2",
+        "express": "^5.1.0",
+        "express-rate-limit": "^8.1.0"
+    },
+    "devDependencies": {
+        "@types/cors": "^2.8.19",
+        "@types/express": "^5.0.3",
+        "@types/node": "^24.5.2",
+        "prisma": "^6.16.2",
+        "tsx": "^4.20.5",
+        "typescript": "^5.9.2"
+    },
+    "prisma": {
+        "seed": "tsx prisma/seed.ts"
+    }
 }

--- a/server/src/middleware/rate-limit.ts
+++ b/server/src/middleware/rate-limit.ts
@@ -1,0 +1,33 @@
+import rateLimit from 'express-rate-limit';
+import type { Request } from 'express';
+import { buildErrorPayload } from '../utils/errors';
+
+const FIFTEEN_MINUTES_IN_MS = 15 * 60 * 1000;
+const MAX_LOGIN_ATTEMPTS = 5;
+
+export const loginRateLimiter = rateLimit({
+  windowMs: FIFTEEN_MINUTES_IN_MS,
+  max: MAX_LOGIN_ATTEMPTS,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req: Request) => req.ip,
+  handler: (req, res) => {
+    const retryAfter = Math.ceil(FIFTEEN_MINUTES_IN_MS / 1000);
+    console.warn('[RateLimit] Login limiter triggered', {
+      ip: req.ip,
+      path: req.originalUrl,
+      limit: MAX_LOGIN_ATTEMPTS,
+      windowMs: FIFTEEN_MINUTES_IN_MS,
+    });
+
+    res
+      .status(429)
+      .setHeader('Retry-After', String(retryAfter))
+      .json(
+        buildErrorPayload(
+          'RATE_LIMITED',
+          'Muitas tentativas de login. Tente novamente em alguns minutos.',
+        ),
+      );
+  },
+});

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -6,10 +6,11 @@ import { publicUserSelect } from '../utils/user';
 import { buildErrorPayload } from '../utils/errors';
 import { signAccessToken } from '../utils/auth';
 import authenticate from '../middleware/authenticate';
+import { loginRateLimiter } from '../middleware/rate-limit';
 
 const router = Router();
 
-router.post('/login', async (req, res, next) => {
+router.post('/login', loginRateLimiter, async (req, res, next) => {
   try {
     const { email, password } = req.body ?? {};
 


### PR DESCRIPTION
## Summary
- add express-rate-limit dependency and expose a reusable login rate limiter middleware
- apply the rate limiter to POST /api/auth/login and log blocked attempts
- document the new rate limit configuration in the authentication guide

## Testing
- npm run lint *(fails: ESLint reports all files are ignored when linting ".")*

------
https://chatgpt.com/codex/tasks/task_e_68d7d9bed258833198408d81fedc522d