### PR TITLE
feat: add structured error logging

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,19 @@
+# Observabilidade
+
+## Logs estruturados de erros
+
+Os erros do backend Express são emitidos agora em JSON estruturado para facilitar a ingestão por ferramentas de observabilidade.
+Cada evento inclui apenas campos seguros em produção:
+
+- `level`: sempre `"error"`.
+- `timestamp`: horário ISO-8601 da emissão.
+- `code`: código semântico da falha (`AppError.code`).
+- `message`: mensagem pronta para operadores.
+- `status`: HTTP status retornado ao cliente.
+- `method` e `path`: informações da rota que originou o erro.
+- `requestId`: propagado a partir do cabeçalho `x-request-id`, quando presente.
+
+Quando `NODE_ENV` não é `production`, o logger adiciona o nó `dev` com metadados úteis para debugging local (detalhes do `AppError`
+e rastros de pilha). Em produção esses campos são omitidos para evitar vazamento de informações sensíveis.
+
+Integre o coletor de logs apontando para o stdout do serviço e configure o parser como JSON para aproveitar os campos estruturados.

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -3,6 +3,7 @@ import cors from 'cors';
 import { env } from './env';
 import routes from './routes';
 import { buildErrorPayload, mapUnknownError } from './utils/errors';
+import { logger } from './logger';
 
 const app = express();
 
@@ -25,9 +26,18 @@ app.use((req, res) => {
   res.status(404).json(buildErrorPayload('NOT_FOUND', `Endpoint ${req.method} ${req.originalUrl} not found`));
 });
 
-app.use((error: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+app.use((error: unknown, req: express.Request, res: express.Response, _next: express.NextFunction) => {
   const appError = mapUnknownError(error);
-  console.error('[Error]', error);
+  logger.error({
+    error,
+    code: appError.code,
+    message: appError.message,
+    status: appError.status,
+    details: appError.details,
+    requestId: req.headers['x-request-id'] as string | string[] | undefined,
+    method: req.method,
+    path: req.originalUrl,
+  });
   res.status(appError.status).json(buildErrorPayload(appError.code, appError.message, appError.details));
 });
 

--- a/server/src/logger.ts
+++ b/server/src/logger.ts
@@ -1,0 +1,64 @@
+const isDevelopment = process.env.NODE_ENV !== 'production';
+
+interface ErrorLogContext {
+  code: string;
+  message: string;
+  status: number;
+  requestId?: string | string[];
+  method?: string;
+  path?: string;
+  details?: unknown;
+  error?: unknown;
+}
+
+function normalizeRequestId(requestId?: string | string[]): string | undefined {
+  if (!requestId) {
+    return undefined;
+  }
+
+  if (Array.isArray(requestId)) {
+    return requestId[0];
+  }
+
+  return requestId;
+}
+
+export const logger = {
+  error(context: ErrorLogContext): void {
+    const payload: Record<string, unknown> = {
+      level: 'error',
+      timestamp: new Date().toISOString(),
+      code: context.code,
+      message: context.message,
+      status: context.status,
+      ...(context.requestId ? { requestId: normalizeRequestId(context.requestId) } : {}),
+      ...(context.method ? { method: context.method } : {}),
+      ...(context.path ? { path: context.path } : {}),
+    };
+
+    if (isDevelopment) {
+      const devPayload: Record<string, unknown> = {};
+
+      if (context.details !== undefined) {
+        devPayload.details = context.details;
+      }
+
+      if (context.error instanceof Error) {
+        devPayload.error = {
+          name: context.error.name,
+          stack: context.error.stack,
+        };
+      } else if (context.error !== undefined) {
+        devPayload.error = context.error;
+      }
+
+      if (Object.keys(devPayload).length > 0) {
+        payload.dev = devPayload;
+      }
+    }
+
+    console.error(JSON.stringify(payload));
+  },
+};
+
+export type { ErrorLogContext };


### PR DESCRIPTION
## Summary
- replace the Express error handler logging with a structured logger that emits sanitized fields
- add an environment-aware logger utility that correlates errors with request metadata
- document the structured logging format and the development-only metadata

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7d9c3e168833181773f02544e5f3d